### PR TITLE
fix: Standardize executable filename in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
 
     - name: Compile Python Script
       run: |
-        pyinstaller --onefile --windowed "OI Import Generator.py"
+        pyinstaller --onefile --windowed --name OI-Import-Generator "OI Import Generator.py"
 
     - name: Create Release
       id: create_release
@@ -43,6 +43,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./dist/OI Import Generator.exe
+        asset_path: ./dist/OI-Import-Generator.exe
         asset_name: OI-Import-Generator.exe
         asset_content_type: application/octet-stream


### PR DESCRIPTION
The workflow was failing to upload the release asset because the expected filename 'OI Import Generator.exe' (with spaces) could not be found. This can happen due to inconsistencies in how paths with spaces are handled by different tools or shells.

This commit modifies the PyInstaller command to explicitly name the output executable `OI-Import-Generator` (which becomes `OI-Import-Generator.exe`). The `asset_path` in the upload step has been updated accordingly. This ensures a consistent, space-free filename, making the process more robust.