### PR TITLE
fix: Ensure unique tag names for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,8 +32,8 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v${{ github.run_number }}
-        release_name: Release v${{ github.run_number }}
+        tag_name: v${{ github.run_number }}-${{ substring(github.sha, 0, 7) }}
+        release_name: Release v${{ github.run_number }}-${{ substring(github.sha, 0, 7) }}
         draft: false
         prerelease: false
 


### PR DESCRIPTION
The workflow was failing when creating a release if a tag with the current `github.run_number` (e.g., v8) already existed. This can happen if workflows are re-run or if tags are created manually.

This commit updates the `tag_name` and `release_name` in the workflow to include the first 7 characters of the commit SHA. The new format is `v<run_number>-<short_sha>` (e.g., v8-123abc7).

This ensures that tag and release names are highly likely to be unique,\preventing collisions and the 'tag_name already_exists' error.