### PR TITLE
feat: Add build script for creating a single-file executable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# PyInstaller
+/build/
+/dist/
+*.spec

--- a/build.py
+++ b/build.py
@@ -1,0 +1,31 @@
+import subprocess
+import sys
+
+def build():
+    """
+    Builds the executable using PyInstaller.
+    """
+    pyinstaller_command = [
+        sys.executable,
+        "-m",
+        "PyInstaller",
+        "--name",
+        "OI_Import_Generator",
+        "--onefile",
+        "--windowed",
+        "oi_import_generator.py",
+    ]
+
+    print(f"Running command: {' '.join(pyinstaller_command)}")
+
+    try:
+        subprocess.run(pyinstaller_command, check=True, capture_output=True, text=True)
+        print("Build successful!")
+    except subprocess.CalledProcessError as e:
+        print("Build failed.")
+        print(e.stdout)
+        print(e.stderr)
+        sys.exit(1)
+
+if __name__ == "__main__":
+    build()


### PR DESCRIPTION
This commit introduces a build script that uses PyInstaller to compile the OI Import Generator application into a single-file executable.

The following changes are included:
- A `build.py` script that runs the PyInstaller command.
- A `.gitignore` file to exclude the `build` and `dist` directories and `*.spec` files from version control.